### PR TITLE
don't rely on __dir__

### DIFF
--- a/lib/pasu/application.rb
+++ b/lib/pasu/application.rb
@@ -4,7 +4,8 @@ module Pasu
     plugin Cuba::Render
     
     settings[:render][:template_engine] = 'slim'
-    settings[:render][:views] = File.join(__dir__, '..', '..', 'views')
+    dir = File.expand_path(File.dirname(__FILE__))
+    settings[:render][:views] = File.join(dir, '..', '..', 'views')
 
     class << self
       def setup(options = {})

--- a/pasu.gemspec
+++ b/pasu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_runtime_dependency 'cuba', '~> 3.1'
   spec.add_runtime_dependency 'cuba-sendfile', '0.0.2'


### PR DESCRIPTION
This makes pasu compatible with Ruby 1.9
